### PR TITLE
Fixed problem for node_modules package.json copy to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "jest",
     "lint": "eslint ./src/**/*.ts",
     "prepare": "husky install",
-    "copy-packages": "powershell -Command \"Get-ChildItem -Path src/functions -Recurse -Filter 'package.json' | ForEach-Object { $dest = 'dist/functions/' + $_.Directory.Name + '/package.json'; New-Item -ItemType Directory -Path (Split-Path $dest) -Force; Copy-Item $_.FullName -Destination $dest -Force; }\"",
+    "copy-packages": "powershell -Command \"Get-ChildItem -Path src/functions -Recurse -Filter 'package.json' | Where-Object { $_.FullName -notmatch 'node_modules' } | ForEach-Object { $dest = 'dist/functions/' + $_.Directory.Name + '/package.json'; New-Item -ItemType Directory -Path (Split-Path $dest) -Force; Copy-Item $_.FullName -Destination $dest -Force; }\"",
     "install-all-src": "powershell -Command \"Get-ChildItem -Path src/functions -Recurse -Filter package.json | ForEach-Object { Push-Location $_.DirectoryName; npm install; Pop-Location }\"",
     "install-all-dist": "powershell -Command \"Get-ChildItem -Path dist/functions -Recurse -Filter package.json | ForEach-Object { Push-Location $_.DirectoryName; npm install; Pop-Location }\""
   },


### PR DESCRIPTION
Removed the situation when `package.json` from `node_modules` was in `dist` in build